### PR TITLE
fix rake task to update records that have not been changed

### DIFF
--- a/lib/tasks/epic_sort.rake
+++ b/lib/tasks/epic_sort.rake
@@ -4,7 +4,7 @@ namespace :sort do
   task epic: :environment do
     puts "Generating Sorting Scores"
     Profile.non_organizers.each do |profile|
-      profile.save
+      profile.touch
     end
   end
 


### PR DESCRIPTION
This should force a save in **rake sort:epic** on all the non-organizer profiles, so the call back gets called that sets the sort order.
